### PR TITLE
fix: name 'tokenizer' is not defined

### DIFF
--- a/sft/utils/utils.py
+++ b/sft/utils/utils.py
@@ -182,6 +182,8 @@ def filter_code(text):
 
 def read_file_from_position_with_filter(args):
     filename, start_position, end_position, worker_id = args
+    tokenizer=args["tokenizer"]
+    max_len=args["max_len"]
     objs = []
     with open(filename, 'r', encoding='utf-8', errors='ignore') as f:
         current_position = find_next_line(f, start_position)


### PR DESCRIPTION
when running binarize_data.py, error occurs  
obj = chatml_format_preprocess(obj["messages"], tokenizer, max_len=32768, only_last_turn_loss=obj["only_last_turn_loss"] if "only_last_turn_loss" in obj else True)
                                                    ^^^^^^^^^
NameError: name 'tokenizer' is not defined