### PR TITLE
fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ pip install -r requirements.txt
 ## Quick Start
 
 > [!Important]
-> **Qwen2.5-Coder-\[0.5-32\]B-Instrcut** are instruction models for chatting;
+> **Qwen2.5-Coder-\[0.5-32\]B-Instruct** are instruction models for chatting;
 >
 > **Qwen2.5-Coder-\[0.5-32\]B** is a base model typically used for completion, serving as a better starting point for fine-tuning.
 >


### PR DESCRIPTION
Noticed a typo in the word "instruct".

On behalf of the [Continue](https://github.com/continuedev/continue) team, thanks for this awesome open-source coding LLM!