### PR TITLE
Bugfix: Scheduler setting conflict.

### DIFF
--- a/finetuning/sft/configs/default_offload_opt_param.json
+++ b/finetuning/sft/configs/default_offload_opt_param.json
@@ -11,15 +11,6 @@
         "weight_decay": "auto"
       }
     },
-    "scheduler": {
-      "type": "WarmupDecayLR",
-      "params": {
-        "total_num_steps": "auto",
-        "warmup_min_lr": "auto",
-        "warmup_max_lr": "auto",
-        "warmup_num_steps": "auto"
-      }
-    },
     "zero_optimization": {
       "stage": 3,
       "offload_optimizer": {


### PR DESCRIPTION
The scheduler was set in [`sft_qwencoder.sh`](https://github.com/QwenLM/Qwen2.5-Coder/blob/186f7370bb70363b100f1b812026703a43240b27/finetuning/sft/scripts/sft_qwencoder.sh#L66).

The schedular **also** was set in [`default_offload_opt_param.json`](https://github.com/QwenLM/Qwen2.5-Coder/blob/186f7370bb70363b100f1b812026703a43240b27/finetuning/sft/configs/default_offload_opt_param.json#L14-L21).

This conflict made some weird behaviors. For example, when running warmup+cosine decay as the `sft_qwencoder.sh` originally set, people expected to get the learning rate like this:

<img width="299" alt="a682830d31c377d0eef8268d7a0798ed" src="https://github.com/user-attachments/assets/c5eaaa08-e833-40e1-867d-9a3c771ffce5" />

However, here is what I got:

<img width="369" alt="ec69bc8941c9cc3fb8d28827a9b8ef09" src="https://github.com/user-attachments/assets/845e5ad0-8ccf-4ee2-a8b3-e7d421155f1c" />

The learning rate warmup has followed some curves and decayed linearly.

After this PR's modification, i.e., removing the config on the DeepSpeed side, the learning rate schedular worked as expected.

<img width="367" alt="image" src="https://github.com/user-attachments/assets/df56f3b6-7868-4c76-a036-65e36dfeaa95" />
